### PR TITLE
VS 2015: Fixed issue that MyHistory isn't displayed in DropDown

### DIFF
--- a/Main/MyHistory/MyHistoryNavigationItem.cs
+++ b/Main/MyHistory/MyHistoryNavigationItem.cs
@@ -7,7 +7,7 @@ namespace Microsoft.ALMRangers.Samples.MyHistory
     using Microsoft.TeamFoundation.Controls;
     using Microsoft.VisualStudio.Shell;
 
-    [TeamExplorerNavigationItem(MyHistoryNavigationItem.LinkId, 200)]
+    [TeamExplorerNavigationItem(MyHistoryNavigationItem.LinkId, 200, TargetPageId = MyHistoryNavigationItem.LinkId)]
     public class MyHistoryNavigationItem : TeamExplorerBaseNavigationItem
     {
         public const string LinkId = "e49a882b-1677-46a9-93b4-db290943bbcd";


### PR DESCRIPTION
Fixed issue that MyHistory entry isn't displayed in the TeamExplorer DropDown as long as the page isn't active